### PR TITLE
added childmap tests and made hasher public

### DIFF
--- a/src/App/ElementMap.h
+++ b/src/App/ElementMap.h
@@ -278,9 +278,11 @@ private:
 
     mutable unsigned _id = 0;
 
+    void init();
+
+public:
     /// String hasher for element name shortening
     App::StringHasherRef hasher;
-    void init();
 };
 
 

--- a/tests/src/App/ElementMap.cpp
+++ b/tests/src/App/ElementMap.cpp
@@ -12,7 +12,7 @@
 class LessComplexPart
 {
 public:
-    LessComplexPart(long tag, const std::string& nameStr)
+    LessComplexPart(long tag, const std::string& nameStr, App::StringHasherRef hasher)
         : elementMapPtr(std::make_shared<Data::ElementMap>())
         , Tag(tag)
         , name(nameStr)
@@ -26,6 +26,7 @@ public:
         auto face4 = Data::IndexedName("Face", 4);
         auto face5 = Data::IndexedName("Face", 5);
         auto face6 = Data::IndexedName("Face", 6);
+        elementMapPtr->hasher = hasher;
         elementMapPtr->setElementName(face1, Data::MappedName(face1), Tag);
         elementMapPtr->setElementName(face2, Data::MappedName(face2), Tag);
         elementMapPtr->setElementName(face3, Data::MappedName(face3), Tag);
@@ -53,13 +54,15 @@ protected:
     void SetUp() override
     {
         App::GetApplication().newDocument("test", "testUser");
-        sids = &_sid;
+        _sids = &_sid;
+        _hasher = Base::Reference<App::StringHasher>(new App::StringHasher);
     }
 
     // void TearDown() override {}
 
     Data::ElementIDRefs _sid;
-    QVector<App::StringIDRef>* sids;
+    QVector<App::StringIDRef>* _sids;
+    App::StringHasherRef _hasher;
 };
 
 TEST_F(ElementMapTest, defaultConstruction)
@@ -79,7 +82,7 @@ TEST_F(ElementMapTest, setElementNameDefaults)
     Data::MappedName mappedName("TEST");
 
     // Act
-    auto resultName = elementMap.setElementName(element, mappedName, 0, sids);
+    auto resultName = elementMap.setElementName(element, mappedName, 0, _sids);
     auto mappedToElement = elementMap.find(element);
 
     // Assert
@@ -99,7 +102,7 @@ TEST_F(ElementMapTest, setElementNameWithHashing)
     // Act
     elementMap.encodeElementName(
         element.getType()[0], elementNameHolder, ss, nullptr, 0, nullptr, 0);
-    auto resultName = elementMap.setElementName(element, elementNameHolder, 0, sids);
+    auto resultName = elementMap.setElementName(element, elementNameHolder, 0, _sids);
     auto mappedToElement = elementMap.find(element);
 
     // Assert
@@ -114,7 +117,7 @@ TEST_F(ElementMapTest, mimicOnePart)
     //   for a single part, there is no "naming algo" to speak of
     std::ostringstream ss;
     auto docName = "Unnamed";
-    LessComplexPart cube(1L, "Box");
+    LessComplexPart cube(1L, "Box", _hasher);
 
     // Act
     auto children = cube.elementMapPtr->getAll();
@@ -146,9 +149,9 @@ TEST_F(ElementMapTest, mimicSimpleUnion)
     std::ostringstream finalSs;
     char* docName = "Unnamed";
 
-    LessComplexPart cube(1L, "Box");
-    LessComplexPart cylinder(2L, "Cylinder");
-    LessComplexPart unionPart(3L, "Fusion");// Union (Fusion) operation via the Part Workbench
+    LessComplexPart cube(1L, "Box", _hasher);
+    LessComplexPart cylinder(2L, "Cylinder", _hasher);
+    LessComplexPart unionPart(3L, "Fusion", _hasher);// Union (Fusion) operation via the Part Workbench
 
     // we are only going to simulate one face for testing purpose
     Data::IndexedName uface3("Face", 3);
@@ -195,6 +198,93 @@ TEST_F(ElementMapTest, mimicSimpleUnion)
     // ",F" means are of type "F" which is short for "Face" of Face3 of Fusion.
     // "." we are done with the second part
     // "Face3" is the localized name
+}
+
+TEST_F(ElementMapTest, hasChildElementMapTest)
+{
+    // Arrange
+    auto child = (Data::ElementMap::MappedChildElements) {
+        Data::IndexedName("face", 1),
+        2,
+        7,
+        4L,
+        Data::ElementMapPtr(),
+        QByteArray("")
+    };
+    std::vector<Data::ElementMap::MappedChildElements> children = { child };
+    LessComplexPart cubeFull(3L, "FullBox", _hasher);
+    cubeFull.elementMapPtr->addChildElements(cubeFull.Tag, children);
+    //
+    LessComplexPart cubeWithoutChildren(2L, "EmptyBox", _hasher);
+
+    // Act
+    bool resultFull = cubeFull.elementMapPtr->hasChildElementMap();
+    bool resultWhenEmpty = cubeWithoutChildren.elementMapPtr->hasChildElementMap();
+
+    // Assert
+    EXPECT_TRUE(resultFull);
+    EXPECT_FALSE(resultWhenEmpty);
+}
+
+TEST_F(ElementMapTest, hashChildMapsTest)
+{
+    // Arrange
+    LessComplexPart cube(1L, "Box", _hasher);
+    auto childOneName = Data::IndexedName("Ping", 1);
+    auto childOne = (Data::ElementMap::MappedChildElements) {
+        childOneName,
+        2,
+        7,
+        3L,
+        Data::ElementMapPtr(),
+        QByteArray("abcdefghij"), // postfix must be 10 or more bytes to invoke hasher
+        _sid
+    };
+    std::vector<Data::ElementMap::MappedChildElements> children = { childOne };
+    cube.elementMapPtr->addChildElements(cube.Tag, children);
+    auto before = _hasher->getIDMap();
+
+    // Act
+    cube.elementMapPtr->hashChildMaps(cube.Tag);
+
+    // Assert
+    auto after = _hasher->getIDMap();
+    EXPECT_EQ(before.size(), 0);
+    EXPECT_EQ(after.size(), 1);
+}
+
+TEST_F(ElementMapTest, addAndGetChildElementsTest)
+{
+    // Arrange
+    LessComplexPart cube(1L, "Box", _hasher);
+    auto childOne = (Data::ElementMap::MappedChildElements) {
+        Data::IndexedName("Ping", 1),
+        2,
+        7,
+        3L,
+        Data::ElementMapPtr(),
+        QByteArray("abcdefghij"), // postfix must be 10 or more bytes to invoke hasher
+        _sid
+    };
+    auto childTwo = (Data::ElementMap::MappedChildElements) {
+        Data::IndexedName("Pong", 2),
+        2,
+        7,
+        4L,
+        Data::ElementMapPtr(),
+        QByteArray("abc"),
+        _sid
+    };
+    std::vector<Data::ElementMap::MappedChildElements> children = { childOne, childTwo };
+
+    // Act
+    cube.elementMapPtr->addChildElements(cube.Tag, children);
+    auto result = cube.elementMapPtr->getChildElements();
+
+    // Assert
+    EXPECT_EQ(result.size(), 2);
+    EXPECT_TRUE(std::any_of(result.begin(), result.end(), [](Data::ElementMap::MappedChildElements e){return e.indexedName.toString()=="Ping1";}));
+    EXPECT_TRUE(std::any_of(result.begin(), result.end(), [](Data::ElementMap::MappedChildElements e){return e.indexedName.toString()=="Pong2";}));
 }
 
 // NOLINTEND(readability-magic-numbers)

--- a/tests/src/App/StringHasher.cpp
+++ b/tests/src/App/StringHasher.cpp
@@ -1295,9 +1295,9 @@ TEST_F(StringHasherTest, getIDFromCString)// NOLINT
  *   3. Raw data and non-raw
  *   4. Postfix contains # and not
  *   5. Indexed name and not
- *   6. sids empty and sids with content
- *   7. sids whose hasher==this and whose hasher is something else
- *   8. If sids.size() > 10, duplicates get removed
+ *   6. _sids empty and _sids with content
+ *   7. _sids whose hasher==this and whose hasher is something else
+ *   8. If _sids.size() > 10, duplicates get removed
  */
 
 TEST_F(StringHasherTest, getIDFromMappedNameWithoutPostfixWithoutIndex)// NOLINT

--- a/tests/src/App/StringHasher.cpp
+++ b/tests/src/App/StringHasher.cpp
@@ -1295,9 +1295,9 @@ TEST_F(StringHasherTest, getIDFromCString)// NOLINT
  *   3. Raw data and non-raw
  *   4. Postfix contains # and not
  *   5. Indexed name and not
- *   6. _sids empty and _sids with content
- *   7. _sids whose hasher==this and whose hasher is something else
- *   8. If _sids.size() > 10, duplicates get removed
+ *   6. sids empty and sids with content
+ *   7. sids whose hasher==this and whose hasher is something else
+ *   8. If sids.size() > 10, duplicates get removed
  */
 
 TEST_F(StringHasherTest, getIDFromMappedNameWithoutPostfixWithoutIndex)// NOLINT


### PR DESCRIPTION
The RealThunder also had the hasher member public. Without that, there is no current way to initialize it or pass in a current StringHasher map.