### PR TITLE
removed bool return from erase and adjusted unit test

### DIFF
--- a/src/App/ElementMap.cpp
+++ b/src/App/ElementMap.cpp
@@ -681,19 +681,19 @@ bool ElementMap::erase(const MappedName& name)
     return true;
 }
 
-bool ElementMap::erase(const IndexedName& idx)
+void ElementMap::erase(const IndexedName& idx)
 {
     auto iter = this->indexedNames.find(idx.getType());
     if (iter == this->indexedNames.end())
-        return false;
+        return;
     auto& indices = iter->second;
     if (idx.getIndex() >= (int)indices.names.size())
-        return false;
+        return;
     auto& ref = indices.names[idx.getIndex()];
     for (auto* r = &ref; r; r = r->next.get())
         this->mappedNames.erase(r->name);
     ref.clear();
-    return true;
+    return;
 }
 
 unsigned long ElementMap::size() const

--- a/src/App/ElementMap.h
+++ b/src/App/ElementMap.h
@@ -130,7 +130,7 @@ public:
     bool erase(const MappedName& name);
 
     /// Remove \c idx and all the MappedNames associated with it
-    bool erase(const IndexedName& idx);
+    void erase(const IndexedName& idx);
 
     unsigned long size() const;
 

--- a/tests/src/App/ElementMap.cpp
+++ b/tests/src/App/ElementMap.cpp
@@ -197,15 +197,15 @@ TEST_F(ElementMapTest, eraseIndexedName)
 
     // Act
     auto sizeBefore = elementMap.size();
-    auto eraseResult = elementMap.erase(element2);
+    elementMap.erase(element2);
     auto sizeAfter = elementMap.size();
-    auto eraseAfterResult = elementMap.erase(element2);
+    elementMap.erase(element2);
+    auto sizeAfterRepeat = elementMap.size();
 
     // Assert
-    EXPECT_EQ(eraseResult, true);
     EXPECT_EQ(sizeBefore, 4);
-    EXPECT_EQ(eraseAfterResult, false);
     EXPECT_EQ(sizeAfter, 2);
+    EXPECT_EQ(sizeAfterRepeat, 2);
 }
 
 TEST_F(ElementMapTest, findMappedName)


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

The `erase` function has a bug in that it does not check for both the "type" (first) and "ref" (second) not existing and returning a false rather than true. It works correctly otherwise.

While the the bug could be easily fixed in the forward direction, it appears that the returned bool value is never actually used by any of the calling code. So, I've simply removed the return value; removing the bug by omission.